### PR TITLE
standard sidebar

### DIFF
--- a/docs/Changes.md
+++ b/docs/Changes.md
@@ -3,6 +3,12 @@ layout: default
 title: Changes
 ---
 
+* [Reuse] Share
+* Changes
+* [Stable version](Stable)
+* [Fix old pattern links](Fix-Old-Links)
+
+
 Changes
 =======
 

--- a/docs/Fix-Old-Links.md
+++ b/docs/Fix-Old-Links.md
@@ -3,6 +3,11 @@ layout: default
 title: Fix Old Links
 ---
 
+* [Reuse] Share
+* [Changes](Changes)
+* [Stable version](Stable)
+* Fix Old Links
+
 Fix Old Links to patterns
 =========================
 

--- a/docs/Reuse.md
+++ b/docs/Reuse.md
@@ -1,10 +1,15 @@
 ---
 layout: default
-title: 3rd party pages
+title: Share
 ---
 
-* [Reuse on 3rd part pages](#reuse-on-3rd-part-pages)
-* [Batch or server side](#Batch-or-server-side)
+* Share
+  * [Reuse on 3rd party pages](#reuse-on-3rd-part-pages)
+  * [Batch or server side](#Batch-or-server-side)
+* [Stay posted](Changes)
+* [Stable version](Stable)
+* [Fix old pattern links](Fix-Old-Links)
+
 
 Reuse on 3rd party pages
 ========================

--- a/docs/Stable.md
+++ b/docs/Stable.md
@@ -3,6 +3,11 @@ layout: default
 title: Stable version / 3rd party pages
 ---
 
+* [Reuse] Share
+* [Changes](Changes)
+* Stable version
+* [Fix old pattern links](Fix-Old-Links)
+
 Stable version
 ==============
 

--- a/docs/_includes/Sidebar.html
+++ b/docs/_includes/Sidebar.html
@@ -3,7 +3,13 @@
        <ul>
            <li><a href="https://groups.io/g/GroundForge" target="_blank">User group</a></li>
            <li><a href="https://groundforge.wordpress.com" target="_blank">Support</a></li>
-           <li><a href="/{{ site.github.repository_name }}/about-us">About us</a></li>
+           <li>
+               {% if page.name == 'about' %}
+               About us
+               {% else %}
+               <a href="/{{ site.github.repository_name }}/about-us">About us</a>
+               {% endif %}
+           </li>
        </ul>
     </li>
     <li><h2>Catalogues</h2>

--- a/docs/_includes/Sidebar.html
+++ b/docs/_includes/Sidebar.html
@@ -100,6 +100,10 @@
     </li>
     <li>
         <a href="https://github.com/d-bl/GroundForge/#licenses"><img src="/GroundForge/assets/images/CC_some_rights_reserved.png"></a>
+        The <a href="https://github.com/d-bl/GroundForge/tree/master/src">code</a>
+        has a <a href="https://github.com/d-bl/GroundForge#licenses">GPL-v3</a> license,
+        the <a href="https://github.com/d-bl/GroundForge/tree/master/docs">pages</a>
+        a <a href="http://creativecommons.org/licenses/by/4.0/">cc-by</a> license.
     </li>
 </ul>
 <!-- Start of StatCounter Code for Default Guide -->

--- a/docs/_includes/Sidebar.html
+++ b/docs/_includes/Sidebar.html
@@ -17,7 +17,7 @@
             <li><a href="/tesselace-to-gf">TesseLace</a></li>
             <li><a href="/gw-lace-to-gf">Gertrude Whiting sampler</a></li>
             <li><a href="/MAE-gf/">Many Attractive Examples</a></li>
-            <li><a href="/MAE-gf/docs/literature/">Literature</a></li>
+            <li><a href="/MAE-gf/docs/literature">Literature</a></li>
         </ul>
     </li>
     <li><h2>GroundForge</h2>

--- a/docs/_includes/Sidebar.html
+++ b/docs/_includes/Sidebar.html
@@ -1,10 +1,4 @@
 <ul>
-    <li><h2>Introduction</h2>
-        <a href="https://github.com/d-bl/GroundForge/blob/oidfa-article/docs/help/DE.md">de</a>,
-        <a href="/{{ site.github.repository_name }}">en</a>,
-        <a href="http://www.gibritte.com/2020/05/jouer-groundforge.html" target="_blank">fr</a>,
-        <a href="https://github.com/d-bl/GroundForge/blob/oidfa-article/docs/help/NL.md">nl</a>
-    </li>
     <li><h2>Contact</h2>
        <ul>
            <li><a href="https://groups.io/g/GroundForge" target="_blank">User group</a></li>
@@ -26,6 +20,12 @@
           <li><a href="/GroundForge/tiles">Main page</a></li>
           <li>User guide</li>
       </ul>
+    </li>
+    <li><h2>Introduction</h2>
+        <a href="https://github.com/d-bl/GroundForge/blob/oidfa-article/docs/help/DE.md">de</a>,
+        <a href="/{{ site.github.repository_name }}">en</a>,
+        <a href="http://www.gibritte.com/2020/05/jouer-groundforge.html" target="_blank">fr</a>,
+        <a href="https://github.com/d-bl/GroundForge/blob/oidfa-article/docs/help/NL.md">nl</a>
     </li>
     <li><h2>Features</h2>
         <ul>

--- a/docs/_includes/Sidebar.html
+++ b/docs/_includes/Sidebar.html
@@ -100,6 +100,7 @@
     </li>
     <li>
         <a href="https://github.com/d-bl/GroundForge/#licenses"><img src="/GroundForge/assets/images/CC_some_rights_reserved.png"></a>
+        <br>
         The <a href="https://github.com/d-bl/GroundForge/tree/master/src">code</a>
         has a <a href="https://github.com/d-bl/GroundForge#licenses">GPL-v3</a> license,
         the <a href="https://github.com/d-bl/GroundForge/tree/master/docs">pages</a>

--- a/docs/_includes/Sidebar.html
+++ b/docs/_includes/Sidebar.html
@@ -91,7 +91,7 @@
     <li><h3>Contribute</h3>
         <ul>
             <li>
-            <li><a href="/GroundForge-help/Reuse">Share</a></li>
+            <li><a href="/GroundForge-help/Reuse">Share and reuse</a></li>
             <li>
                 <a href="https://help.github.com/articles/editing-files-in-another-user-s-repository/">Propose changes</a> to
                 <a href="https://github.com/d-bl/GroundForge-help/tree/master/docs">help </a> pages

--- a/docs/_includes/Sidebar.html
+++ b/docs/_includes/Sidebar.html
@@ -22,8 +22,7 @@
     </li>
     <li><h2>GroundForge</h2>
       <ul>
-          <li><a href="/GroundForge/nets">Nets page</a></li>
-          <li><a href="/GroundForge/tiles">Main page</a></li>
+          <li><a href="/GroundForge/tiles">Diagram editor</a></li>
           <li>
               {% if page.name == 'about-us.md' %}
               <a href="/GroundForge/">User guide</a>
@@ -31,6 +30,7 @@
               User guide
               {% endif %}
           </li>
+          <li><a href="/GroundForge/nets">Net variations</a></li>
       </ul><hr/>
     </li>
     <li><h2>User guide</h2><h3>Introduction</h3>

--- a/docs/_includes/Sidebar.html
+++ b/docs/_includes/Sidebar.html
@@ -2,7 +2,7 @@
     <li><h2>Contact</h2>
        <ul>
            <li><a href="https://groups.io/g/GroundForge" target="_blank">User group</a></li>
-           <li><a href="https://groundforge.wordpress.com">Support</a></li>
+           <li><a href="https://groundforge.wordpress.com" target="_blank">Support</a></li>
            <li><a href="/{{ site.github.repository_name }}/about-us">About us</a></li>
        </ul>
     </li>

--- a/docs/_includes/Sidebar.html
+++ b/docs/_includes/Sidebar.html
@@ -20,8 +20,7 @@
             <li><a href="/MAE-gf/docs/literature/">Literature</a></li>
         </ul>
     </li>
-    <li><h2>GroundForge</h2></li>
-    <li>
+    <li><h2>GroundForge</h2>
       <ul>
           <li><a href="/GroundForge/nets">Nets page</a></li>
           <li><a href="/GroundForge/tiles">Main page</a></li>

--- a/docs/_includes/Sidebar.html
+++ b/docs/_includes/Sidebar.html
@@ -34,11 +34,11 @@
             <li><a href="/{{ site.github.repository_name }}/Patch-Size">Patch Size</a></li>
             <li>
                 <a href="/{{ site.github.repository_name }}/Thread-Properties">Thread properties</a>
-                <img src="/GroundForge-helpimages/toggle-thread.png">
+                <img src="/GroundForge-help/images/toggle-thread.png">
             </li>
             <li>
                 <a href="/{{ site.github.repository_name }}/Replace">Change stitches</a>
-                <img src="/GroundForge-helpimages/toggle-stitch.png">
+                <img src="/GroundForge-help/images/toggle-stitch.png">
             </li>
             <li>
                 <a href="/{{ site.github.repository_name }}/Change-tiles">Tile layout</a>

--- a/docs/_includes/Sidebar.html
+++ b/docs/_includes/Sidebar.html
@@ -21,13 +21,13 @@
           <li>User guide</li>
       </ul><hr/>
     </li>
-    <li><h2>Introduction</h2>
+    <li><h2>User guide</h2><h3>Introduction</h3>
         <a href="https://github.com/d-bl/GroundForge/blob/oidfa-article/docs/help/DE.md">de</a>,
         <a href="/{{ site.github.repository_name }}">en</a>,
         <a href="http://www.gibritte.com/2020/05/jouer-groundforge.html" target="_blank">fr</a>,
         <a href="https://github.com/d-bl/GroundForge/blob/oidfa-article/docs/help/NL.md">nl</a>
     </li>
-    <li><h2>Features</h2>
+    <li><h3>Features</h3>
         <ul>
             <li><a href="/{{ site.github.repository_name }}/Patch-Size">Patch Size</a></li>
             <li>
@@ -66,7 +66,7 @@
         </ul>
     </li>
 
-    <li><h2>Tutorials</h2>
+    <li><h3>Tutorials</h3>
         <ul>
             <li><a href="/{{ site.github.repository_name }}/index">Getting Started</a>
             <li><a href="/{{ site.github.repository_name }}/Advanced">Create a pattern</a></li>
@@ -76,7 +76,7 @@
             <li><a href="/{{ site.github.repository_name }}/Pin-distances-and-angles">Pin distances and angles</a></li>
         </ul>
     </li>
-    <li><h2>Contribute</h2>
+    <li><h3>Contribute</h3>
         <ul>
             <li>
             <li><a href="/{{ site.github.repository_name }}/Reuse">Share</a></li>

--- a/docs/_includes/Sidebar.html
+++ b/docs/_includes/Sidebar.html
@@ -7,7 +7,7 @@
                {% if page.name == 'about-us.md' %}
                About us
                {% else %}
-               <a href="/{{ site.github.repository_name }}/about-us">About us</a>
+               <a href="/GroundForge-help/about-us">About us</a>
                {% endif %}
            </li>
        </ul>
@@ -41,60 +41,60 @@
     </li>
     <li><h3>Features</h3>
         <ul>
-            <li><a href="/{{ site.github.repository_name }}/Patch-Size">Patch Size</a></li>
+            <li><a href="/GroundForge-help/Patch-Size">Patch Size</a></li>
             <li>
-                <a href="/{{ site.github.repository_name }}/Thread-Properties">Thread properties</a>
+                <a href="/GroundForge-help/Thread-Properties">Thread properties</a>
                 <img src="/GroundForge-help/images/toggle-thread.png">
             </li>
             <li>
-                <a href="/{{ site.github.repository_name }}/Replace">Change stitches</a>
+                <a href="/GroundForge-help/Replace">Change stitches</a>
                 <img src="/GroundForge-help/images/toggle-stitch.png">
             </li>
             <li>
-                <a href="/{{ site.github.repository_name }}/Change-tiles">Tile layout</a>
+                <a href="/GroundForge-help/Change-tiles">Tile layout</a>
                 <img src="/GroundForge-help/images/brick-menu-icon.png">
             </li>
             <li>
-                <a href="/{{ site.github.repository_name }}/Undo">
+                <a href="/GroundForge-help/Undo">
                     Save, refresh, undo
                 </a>
                 <img src="/GroundForge/images/link.png">
                 <img src="/GroundForge/images/wand.png">
             </li>
             <li>
-                <a href="/{{ site.github.repository_name }}/Icons">Resize space</a>
+                <a href="/GroundForge-help/Icons">Resize space</a>
                 <img src="/GroundForge/images/size-inc.jpg">
                 <img src="/GroundForge/images/size-dec.jpg">
             </li>
             <li>
-                <a href="/{{ site.github.repository_name }}/Icons">Animate</a>
+                <a href="/GroundForge-help/Icons">Animate</a>
                 <img src="/GroundForge/images/animate.png">
             </li>
             <li>
-                <a href="/{{ site.github.repository_name }}/Download">Download</a>
+                <a href="/GroundForge-help/Download">Download</a>
                 <img src="/GroundForge/images/download.jpg">
             </li>
-            <li><a href="/{{ site.github.repository_name }}/Color-Code">Color code, Twist marks</a> <img src="/GroundForge/images/swatches.png"></li>
+            <li><a href="/GroundForge-help/Color-Code">Color code, Twist marks</a> <img src="/GroundForge/images/swatches.png"></li>
         </ul>
     </li>
 
     <li><h3>Tutorials</h3>
         <ul>
-            <li><a href="/{{ site.github.repository_name }}/index">Getting Started</a>
-            <li><a href="/{{ site.github.repository_name }}/Advanced">Create a pattern</a></li>
-            <li><a href="/{{ site.github.repository_name }}/Droste-effect">Droste effect</a></li>
-            <li><a href="/{{ site.github.repository_name }}/Reshape-Patterns">Reshape pair diagrams</a></li>
-            <li><a href="/{{ site.github.repository_name }}/Reversed-engineering-of-patterns">Printed patterns to GF</a></li>
-            <li><a href="/{{ site.github.repository_name }}/Pin-distances-and-angles">Pin distances and angles</a></li>
+            <li><a href="/GroundForge-help/index">Getting Started</a>
+            <li><a href="/GroundForge-help/Advanced">Create a pattern</a></li>
+            <li><a href="/GroundForge-help/Droste-effect">Droste effect</a></li>
+            <li><a href="/GroundForge-help/Reshape-Patterns">Reshape pair diagrams</a></li>
+            <li><a href="/GroundForge-help/Reversed-engineering-of-patterns">Printed patterns to GF</a></li>
+            <li><a href="/GroundForge-help/Pin-distances-and-angles">Pin distances and angles</a></li>
         </ul>
     </li>
     <li><h3>Contribute</h3>
         <ul>
             <li>
-            <li><a href="/{{ site.github.repository_name }}/Reuse">Share</a></li>
+            <li><a href="/GroundForge-help/Reuse">Share</a></li>
             <li>
                 <a href="https://help.github.com/articles/editing-files-in-another-user-s-repository/">Propose changes</a> to
-                <a href="https://github.com/d-bl/{{ site.github.repository_name }}/tree/master/docs">help </a> pages
+                <a href="https://github.com/d-bl/GroundForge-help/tree/master/docs">help </a> pages
             </li>
         </ul>
     </li>

--- a/docs/_includes/Sidebar.html
+++ b/docs/_includes/Sidebar.html
@@ -14,8 +14,8 @@
     </li>
     <li><h2>Catalogues</h2>
         <ul>
-            <li><a href="/tesselace-to-gf">TesseLace</a>
-            <li><a href="/gw-lace-to-gf">Whiting</a>
+            <li><a href="/tesselace-to-gf">TesseLace</a></li>
+            <li><a href="/gw-lace-to-gf">Gertrude Whiting sampler</a></li>
             <li><a href="/MAE-gf/">Many Attractive Examples</a></li>
             <li><a href="/MAE-gf/docs/literature/">Literature</a></li>
         </ul>

--- a/docs/_includes/Sidebar.html
+++ b/docs/_includes/Sidebar.html
@@ -88,7 +88,8 @@
             <li><a href="/GroundForge-help/Pin-distances-and-angles">Pin distances and angles</a></li>
         </ul>
     </li>
-    <li><h3>Contribute</h3>
+    <li><hr>
+        <h3>Contribute</h3>
         <ul>
             <li>
             <li><a href="/GroundForge-help/Reuse">Share and reuse</a></li>

--- a/docs/_includes/Sidebar.html
+++ b/docs/_includes/Sidebar.html
@@ -1,18 +1,18 @@
 <ul>
-    <li>Introduction<br>
+    <li><h2>Introduction</h2><br>
         <a href="https://github.com/d-bl/GroundForge/blob/oidfa-article/docs/help/DE.md">de</a>,
         <a href="/{{ site.github.repository_name }}">en</a>,
         <a href="http://www.gibritte.com/2020/05/jouer-groundforge.html" target="_blank">fr</a>,
         <a href="https://github.com/d-bl/GroundForge/blob/oidfa-article/docs/help/NL.md">nl</a>
     </li>
-    <li>Contact:
+    <li><h2>Contact</h2>
        <ul>
-           <li><a href="https://groups.io/g/GroundForge" target="_blank">user group</a></li>
-           <li><a href="https://groundforge.wordpress.com">support</a></li>
-           <li><a href="/{{ site.github.repository_name }}/about-us">about-us</a></li>
+           <li><a href="https://groups.io/g/GroundForge" target="_blank">User group</a></li>
+           <li><a href="https://groundforge.wordpress.com">Support</a></li>
+           <li><a href="/{{ site.github.repository_name }}/about-us">About us</a></li>
        </ul>
     </li>
-    <li>Catalogues
+    <li><h2>Catalogues</h2>
         <ul>
             <li><a href="/tesselace-to-gf">TesseLace</a>
             <li><a href="/gw-lace-to-gf">Whiting</a>
@@ -20,7 +20,15 @@
             <li><a href="/MAE-gf/docs/literature/">Literature</a></li>
         </ul>
     </li>
-    <li>Features
+    <li><h2>GroundForge</h2></li>
+    <li>
+      <ul>
+          <li><a href="/GroundForge/nets">Nets page</a></li>
+          <li><a href="/GroundForge/tiles">Main page</a></li>
+          <li>User guide</li>
+      </ul>
+    </li>
+    <li><h2>Features</h2>
         <ul>
             <li><a href="/{{ site.github.repository_name }}/Patch-Size">Patch Size</a></li>
             <li>
@@ -37,7 +45,7 @@
             </li>
             <li>
                 <a href="/{{ site.github.repository_name }}/Undo">
-                    save, refresh, undo
+                    Save, refresh, undo
                 </a>
                 <img src="/GroundForge/images/link.png">
                 <img src="/GroundForge/images/wand.png">
@@ -59,39 +67,28 @@
         </ul>
     </li>
 
-    <li>Tutorials
+    <li><h2>Tutorials</h2>
         <ul>
             <li><a href="/{{ site.github.repository_name }}/index">Getting Started</a>
             <li><a href="/{{ site.github.repository_name }}/Advanced">Create a pattern</a></li>
             <li><a href="/{{ site.github.repository_name }}/Droste-effect">Droste effect</a></li>
-            <li><a href="/{{ site.github.repository_name }}/Reshape-Patterns">Reshape Pair Diagrams</a></li>
+            <li><a href="/{{ site.github.repository_name }}/Reshape-Patterns">Reshape pair diagrams</a></li>
             <li><a href="/{{ site.github.repository_name }}/Reversed-engineering-of-patterns">Printed patterns to GF</a></li>
             <li><a href="/{{ site.github.repository_name }}/Pin-distances-and-angles">Pin distances and angles</a></li>
         </ul>
     </li>
-    <li>
-        <a href="https://github.com/d-bl/GroundForge/#licenses"><img src="/GroundForge/assets/images/CC_some_rights_reserved.png"></a>
-    </li>
-    <li>Contribute
+    <li><h2>Contribute</h2>
         <ul>
             <li>
-                <a href="https://groups.io/g/GroundForge" target="_blank">share your patterns</a>
-            </li>
+            <li><a href="/{{ site.github.repository_name }}/Reuse">Share</a></li>
             <li>
-                <a href="https://help.github.com/articles/editing-files-in-another-user-s-repository/">propose changes</a> to
+                <a href="https://help.github.com/articles/editing-files-in-another-user-s-repository/">Propose changes</a> to
                 <a href="https://github.com/d-bl/{{ site.github.repository_name }}/tree/master/docs">help </a> pages
             </li>
         </ul>
     </li>
-    <li>Development information
-        <ul>
-            <li><a href="/{{ site.github.repository_name }}/Reuse">Use on 3rd party sites</a></li>
-            <li>Issues: <a href="https://github.com/d-bl/{{ site.github.repository_name }}/issues?q=is%3Aissue+is%3Aopen+label%3A%22Browser+support%22">browsers</a> /
-                <a href="https://github.com/d-bl/{{ site.github.repository_name }}/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+-label%3A%22Browser+support%22">others</a></li>
-            <li><a href="/{{ site.github.repository_name }}/Changes">Stay posted</a></li>
-            <li><a href="/{{ site.github.repository_name }}/Stable">Stable version</a></li>
-            <li><a href="/{{ site.github.repository_name }}/Fix-Old-Links">Fix old pattern links</a></li>
-        </ul>
+    <li>
+        <a href="https://github.com/d-bl/GroundForge/#licenses"><img src="/GroundForge/assets/images/CC_some_rights_reserved.png"></a>
     </li>
 </ul>
 <!-- Start of StatCounter Code for Default Guide -->

--- a/docs/_includes/Sidebar.html
+++ b/docs/_includes/Sidebar.html
@@ -9,7 +9,6 @@
                {% else %}
                <a href="/{{ site.github.repository_name }}/about-us">About us</a>
                {% endif %}
-               {{ page.name }}
            </li>
        </ul>
     </li>

--- a/docs/_includes/Sidebar.html
+++ b/docs/_includes/Sidebar.html
@@ -9,6 +9,7 @@
        <ul>
            <li><a href="https://groups.io/g/GroundForge" target="_blank">user group</a></li>
            <li><a href="https://groundforge.wordpress.com">support</a></li>
+           <li><a href="/{{ site.github.repository_name }}/about-us">about-us</a></li>
        </ul>
     </li>
     <li>Contribute

--- a/docs/_includes/Sidebar.html
+++ b/docs/_includes/Sidebar.html
@@ -93,8 +93,8 @@
             <li>
             <li><a href="/GroundForge-help/Reuse">Share and reuse</a></li>
             <li>
-                <a href="https://help.github.com/articles/editing-files-in-another-user-s-repository/">Propose changes</a> to
-                <a href="https://github.com/d-bl/GroundForge-help/tree/master/docs">help </a> pages
+                <a href="https://help.github.com/articles/editing-files-in-another-user-s-repository/" target="_blank">Propose changes</a> to
+                <a href="https://github.com/d-bl/GroundForge-help/tree/master/docs" target="_blank">help </a> pages
             </li>
         </ul>
     </li>

--- a/docs/_includes/Sidebar.html
+++ b/docs/_includes/Sidebar.html
@@ -1,5 +1,5 @@
 <ul>
-    <li><h2>Introduction</h2><br>
+    <li><h2>Introduction</h2>
         <a href="https://github.com/d-bl/GroundForge/blob/oidfa-article/docs/help/DE.md">de</a>,
         <a href="/{{ site.github.repository_name }}">en</a>,
         <a href="http://www.gibritte.com/2020/05/jouer-groundforge.html" target="_blank">fr</a>,

--- a/docs/_includes/Sidebar.html
+++ b/docs/_includes/Sidebar.html
@@ -9,6 +9,7 @@
                {% else %}
                <a href="/{{ site.github.repository_name }}/about-us">About us</a>
                {% endif %}
+               {{ page.name }}
            </li>
        </ul>
     </li>

--- a/docs/_includes/Sidebar.html
+++ b/docs/_includes/Sidebar.html
@@ -23,7 +23,7 @@
     </li>
     <li><h2>User guide</h2><h3>Introduction</h3>
         <a href="https://github.com/d-bl/GroundForge/blob/oidfa-article/docs/help/DE.md">de</a>,
-        <a href="/{{ site.github.repository_name }}">en</a>,
+        <a href="/GroundForge/">en</a>,
         <a href="http://www.gibritte.com/2020/05/jouer-groundforge.html" target="_blank">fr</a>,
         <a href="https://github.com/d-bl/GroundForge/blob/oidfa-article/docs/help/NL.md">nl</a>
     </li>

--- a/docs/_includes/Sidebar.html
+++ b/docs/_includes/Sidebar.html
@@ -4,7 +4,7 @@
            <li><a href="https://groups.io/g/GroundForge" target="_blank">User group</a></li>
            <li><a href="https://groundforge.wordpress.com" target="_blank">Support</a></li>
            <li>
-               {% if page.name == 'about' %}
+               {% if page.name == 'about-us.md' %}
                About us
                {% else %}
                <a href="/{{ site.github.repository_name }}/about-us">About us</a>
@@ -25,7 +25,13 @@
       <ul>
           <li><a href="/GroundForge/nets">Nets page</a></li>
           <li><a href="/GroundForge/tiles">Main page</a></li>
-          <li>User guide</li>
+          <li>
+              {% if page.name == 'about-us.md' %}
+              <a href="/GroundForge/">User guide</a>
+              {% else %}
+              User guide
+              {% endif %}
+          </li>
       </ul><hr/>
     </li>
     <li><h2>User guide</h2><h3>Introduction</h3>

--- a/docs/_includes/Sidebar.html
+++ b/docs/_includes/Sidebar.html
@@ -12,22 +12,12 @@
            <li><a href="/{{ site.github.repository_name }}/about-us">about-us</a></li>
        </ul>
     </li>
-    <li>Contribute
-        <ul>
-           <li>
-               <a href="https://groups.io/g/GroundForge" target="_blank">share your patterns</a>
-           </li>
-            <li>
-                <a href="https://help.github.com/articles/editing-files-in-another-user-s-repository/">propose changes</a> to
-                <a href="https://github.com/d-bl/{{ site.github.repository_name }}/tree/master/docs">help </a> pages
-            </li>
-        </ul>
-    </li>
     <li>Catalogues
         <ul>
             <li><a href="/tesselace-to-gf">TesseLace</a>
             <li><a href="/gw-lace-to-gf">Whiting</a>
             <li><a href="/MAE-gf/">Many Attractive Examples</a></li>
+            <li><a href="/MAE-gf/docs/literature/">Literature</a></li>
         </ul>
     </li>
     <li>Features
@@ -81,6 +71,17 @@
     </li>
     <li>
         <a href="https://github.com/d-bl/GroundForge/#licenses"><img src="/GroundForge/assets/images/CC_some_rights_reserved.png"></a>
+    </li>
+    <li>Contribute
+        <ul>
+            <li>
+                <a href="https://groups.io/g/GroundForge" target="_blank">share your patterns</a>
+            </li>
+            <li>
+                <a href="https://help.github.com/articles/editing-files-in-another-user-s-repository/">propose changes</a> to
+                <a href="https://github.com/d-bl/{{ site.github.repository_name }}/tree/master/docs">help </a> pages
+            </li>
+        </ul>
     </li>
     <li>Development information
         <ul>

--- a/docs/_includes/Sidebar.html
+++ b/docs/_includes/Sidebar.html
@@ -14,7 +14,7 @@
     </li>
     <li><h2>Catalogues</h2>
         <ul>
-            <li><a href="/tesselace-to-gf">TesseLace</a></li>
+            <li><a href="/tesselace-to-gf">TesseLace index</a></li>
             <li><a href="/gw-lace-to-gf">Gertrude Whiting sampler</a></li>
             <li><a href="/MAE-gf/">Many Attractive Examples</a></li>
             <li><a href="/MAE-gf/docs/literature">Literature</a></li>

--- a/docs/_includes/Sidebar.html
+++ b/docs/_includes/Sidebar.html
@@ -5,9 +5,6 @@
         <a href="http://www.gibritte.com/2020/05/jouer-groundforge.html" target="_blank">fr</a>,
         <a href="https://github.com/d-bl/GroundForge/blob/oidfa-article/docs/help/NL.md">nl</a>
     </li>
-    <li>
-        <a href="https://github.com/d-bl/GroundForge/#licenses"><img src="/GroundForge/assets/images/CC_some_rights_reserved.png"></a>
-    </li>
     <li>Contact:
        <ul>
            <li><a href="https://groups.io/g/GroundForge" target="_blank">user group</a></li>
@@ -37,15 +34,15 @@
             <li><a href="/{{ site.github.repository_name }}/Patch-Size">Patch Size</a></li>
             <li>
                 <a href="/{{ site.github.repository_name }}/Thread-Properties">Thread properties</a>
-                <img src="images/toggle-thread.png">
+                <img src="/GroundForge-helpimages/toggle-thread.png">
             </li>
             <li>
                 <a href="/{{ site.github.repository_name }}/Replace">Change stitches</a>
-                <img src="images/toggle-stitch.png">
+                <img src="/GroundForge-helpimages/toggle-stitch.png">
             </li>
             <li>
                 <a href="/{{ site.github.repository_name }}/Change-tiles">Tile layout</a>
-                <img src="images/brick-menu-icon.png">
+                <img src="/GroundForge-help/images/brick-menu-icon.png">
             </li>
             <li>
                 <a href="/{{ site.github.repository_name }}/Undo">
@@ -81,7 +78,9 @@
             <li><a href="/{{ site.github.repository_name }}/Pin-distances-and-angles">Pin distances and angles</a></li>
         </ul>
     </li>
-
+    <li>
+        <a href="https://github.com/d-bl/GroundForge/#licenses"><img src="/GroundForge/assets/images/CC_some_rights_reserved.png"></a>
+    </li>
     <li>Development information
         <ul>
             <li><a href="/{{ site.github.repository_name }}/Reuse">Use on 3rd party sites</a></li>
@@ -93,13 +92,6 @@
         </ul>
     </li>
 </ul>
-<p>
-    Powered by<br>
-    <a href="https://tesselace.com" title="Algorithmically designed lace tessellations">TesseLace</a> -
-    <a href="https://d3js.org" title="Data Driven Documents">D3.js</a> (force graphs) -
-    <a href="http://ecotrust-canada.github.io/markdown-toc/">markdown-toc</a> -
-    <a href="http://browserstack.com/">browserstack</a>
-</p>
 <!-- Start of StatCounter Code for Default Guide -->
 <script type="text/javascript">
         var sc_project=10865294;

--- a/docs/_includes/Sidebar.html
+++ b/docs/_includes/Sidebar.html
@@ -19,7 +19,7 @@
           <li><a href="/GroundForge/nets">Nets page</a></li>
           <li><a href="/GroundForge/tiles">Main page</a></li>
           <li>User guide</li>
-      </ul>
+      </ul><hr/>
     </li>
     <li><h2>Introduction</h2>
         <a href="https://github.com/d-bl/GroundForge/blob/oidfa-article/docs/help/DE.md">de</a>,

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -53,8 +53,6 @@
 
         <aside id="sidebar" lang="en">
             {% include Sidebar.html %}
-
-            <p>Published with <a href="https://pages.github.com">GitHub Pages</a>.</p>
         </aside>
     </div>
 </div>

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -18,8 +18,6 @@
     {% endif %}
 
     {% seo %}
-
-
     <link rel="apple-touch-icon" sizes="120x120" href="/{{ site.github.repository_name }}/favicon/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/{{ site.github.repository_name }}/favicon/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="/{{ site.github.repository_name }}/favicon/favicon-16x16.png">

--- a/docs/about-us.md
+++ b/docs/about-us.md
@@ -7,7 +7,7 @@ title: About us
 
 * [Jo Pol](#jo-pol)
 * [Marian Tempels](#marian-tempels)
-* Veronika Irvine<br>introduces herself on her [Tesselace](https://tesselace.com/about/) website
+* <a href="https://tesselace.com/about/" target="_blank">Veronika Irvine</a>
 
 ## Jo Pol
 

--- a/docs/about-us.md
+++ b/docs/about-us.md
@@ -3,18 +3,17 @@ layout: default
 title: About us
 ---
 
-# About us
-
-## Contents
+# About us - The support team
 
 * [Jo Pol](#jo-pol)
 * [Marian Tempels](#marian-tempels)
+* [Veronika Irvine](#veronika-irvine)
 
 ## Jo Pol
 
 Living in the Netherlands.
 
-My childhood friend was fond of playing with dolls,
+My childhood friend was fond of playing stories with her dolls,
 I was more interested in the leftovers from her mother's sewing activities to dress my dolls.
 It is just an example of the many crafts I tried for a longer or shorter period.
 My grammar school was an early adopter in offering computer programming courses, it determined my choice of career.
@@ -41,6 +40,7 @@ Inspired by "Hollandsche kant" I started to experiment with the rose-ground, usi
 
 I studied Mathematics at Technical University Eindhoven and work as data- and rules-analyst.    
 
+## Veronika Irvine
 ***
 [&uArr;]()
 

--- a/docs/about-us.md
+++ b/docs/about-us.md
@@ -7,7 +7,7 @@ title: About us
 
 * [Jo Pol](#jo-pol)
 * [Marian Tempels](#marian-tempels)
-* [Veronika Irvine](#veronika-irvine)
+* Veronika Irvine<br>introduces herself on her [Tesselace](https://tesselace.com/about/) website
 
 ## Jo Pol
 
@@ -39,8 +39,4 @@ My lace-making got a tremendous boost when I joined the De Waaier lace group. I 
 Inspired by "Hollandsche kant" I started to experiment with the rose-ground, using unorthodox stitches like "cross only" or "do nothing". Also, I joined the units of the rose ground with plaits. These works were published in the "Kantbrief", the magazine from the dutch lace-society LOKK, and in "bulletin OIDFA".   
 
 I studied Mathematics at Technical University Eindhoven and work as data- and rules-analyst.    
-
-## Veronika Irvine
-
-She introduces herself on her [Tesselace](https://tesselace.com/about/) website.
 

--- a/docs/about-us.md
+++ b/docs/about-us.md
@@ -17,9 +17,9 @@ My childhood friend was fond of playing stories with her dolls,
 I was more interested in the leftovers from her mother's sewing activities to dress my dolls.
 It is just an example of the many crafts I tried for a longer or shorter period.
 My grammar school was an early adopter in offering computer programming courses, it determined my choice of career.
-A bobbin lace demo around the same time draw my attention and with the help of library books I got hooked.
+A bobbin lace demo around the same time draw my attention and with the help of library books I got hooked for life.
 
-Since a workshop "Flanders differently" given by the LOKK,
+Since a workshop "Flanders differently" given by the Dutch lace guild LOKK,
 I wanted the computer to turn color coded pair diagrams into thread diagrams.
 But at that time I lacked the skills to do it myself and
 details of the required concepts were too abstract to convince others.

--- a/docs/about-us.md
+++ b/docs/about-us.md
@@ -41,7 +41,6 @@ Inspired by "Hollandsche kant" I started to experiment with the rose-ground, usi
 I studied Mathematics at Technical University Eindhoven and work as data- and rules-analyst.    
 
 ## Veronika Irvine
-***
-[&uArr;]()
 
+She introduces herself on her [Tesselace](https://tesselace.com/about/) website.
 

--- a/docs/about-us.md
+++ b/docs/about-us.md
@@ -1,0 +1,47 @@
+---
+layout: default
+title: About us
+---
+
+# About us
+
+## Contents
+
+* [Jo Pol](#jo-pol)
+* [Marian Tempels](#marian-tempels)
+
+## Jo Pol
+
+Living in the Netherlands.
+
+My childhood friend was fond of playing with dolls,
+I was more interested in the leftovers from her mother's sewing activities to dress my dolls.
+It is just an example of the many crafts I tried for a longer or shorter period.
+My grammar school was an early adopter in offering computer programming courses, it determined my choice of career.
+A bobbin lace demo around the same time draw my attention and with the help of library books I got hooked.
+
+Since a workshop "Flanders differently" given by the LOKK,
+I wanted the computer to turn color coded pair diagrams into thread diagrams.
+But at that time I lacked the skills to do it myself and
+details of the required concepts were too abstract to convince others.
+But at last I could combine work and hobby, or should I say, both of my hobbies?
+Lace diagrams and grids became exercise subjects to master new programming skills.
+It works in both directions. Slowly I acquired the skills to grow the exercises into something useful.
+I'm happy to share the results with you.
+
+## Marian Tempels
+
+Living in the Netherlands.        
+
+I do not remember when I learned to knit etcetera, must have been at age 6 or something. I do remember knitting a doll at primary school, when I was about age 10. Also, I remember being very disappointed when I was not chosen for attending a weaving-class. At the end of secondary school I had crocheted a wardrobe for a little doll, sewed "aliens" (funny shaped puppets) and made lots of embroidery works. Most of those works are lost somewhere, alas. I did learn to weave, though.
+
+I started making lace about 1980. Worked my way through "Slag voor slag" by Zus Boelaars. Some years later I took lessons, still working traditional.   
+My lace-making got a tremendous boost when I joined the De Waaier lace group. I started taking classes in different styles including modern lace.           
+Inspired by "Hollandsche kant" I started to experiment with the rose-ground, using unorthodox stitches like "cross only" or "do nothing". Also, I joined the units of the rose ground with plaits. These works were published in the "Kantbrief", the magazine from the dutch lace-society LOKK, and in "bulletin OIDFA".   
+
+I studied Mathematics at Technical University Eindhoven and work as data- and rules-analyst.    
+
+***
+[&uArr;]()
+
+

--- a/docs/assets/css/help.css
+++ b/docs/assets/css/help.css
@@ -12,7 +12,7 @@ Header { background: #3679cd url(../images/header-bg-left.png) top right repeat;
 #sidebar sub { font-weight: normal; }
 #sidebar li { list-style-type: none; padding-bottom: 8px; }
 #sidebar li li { padding-bottom: 0; }
-#sidebar hr { height: 12px; border: 0; box-shadow: inset 0 12px 12px -12px rgba(0, 0, 0, 0.2); }
+#sidebar hr { height: 12px; border: 0; margin-bottom: 0; box-shadow: inset 0 12px 12px -12px rgba(0, 0, 0, 0.2); }
 #sidebar h2 { margin-bottom: 0; margin-top: 3px; }
 
 #fallBack { border: 10px solid orange; padding: 5px; }

--- a/docs/assets/css/help.css
+++ b/docs/assets/css/help.css
@@ -5,8 +5,8 @@ Header { background: #3679cd url(../images/header-bg-left.png) top right repeat;
         background-color: #3679cd
     }
 }
-@only screen and (min-width: 960px) {
-    header h1 { width 580px }
+@media only screen and (min-width: 768px) and (max-width: 959px) {
+  header h1, header h2 { width: 380px; }
 }
 
 #sidebar strong { font-size: 18px; font-family: 'Architects Daughter', 'Helvetica Neue', Helvetica, Arial, serif; }

--- a/docs/assets/css/help.css
+++ b/docs/assets/css/help.css
@@ -8,10 +8,10 @@ Header { background: #3679cd url(../images/header-bg-left.png) top right repeat;
 
 #sidebar strong { font-size: 18px; font-family: 'Architects Daughter', 'Helvetica Neue', Helvetica, Arial, serif; }
 #sidebar ul { padding-left: 0; margin-bottom: 0px; font-weight: bold; font-size: 12px; color: #474747; }
-#sidebar ul ul { padding-left: 15px; font-weight: normal; }
+#sidebar ul ul { font-weight: normal; }
 #sidebar sub { font-weight: normal; }
 #sidebar li { list-style-type: none; padding-bottom: 8px; }
-#sidebar li li { padding-bottom: 0;}
+#sidebar li li { padding-bottom: 0; }
 #sidebar hr { height: 12px; border: 0; box-shadow: inset 0 12px 12px -12px rgba(0, 0, 0, 0.2); }
 
 #fallBack { border: 10px solid orange; padding: 5px; }

--- a/docs/assets/css/help.css
+++ b/docs/assets/css/help.css
@@ -12,7 +12,6 @@ Header { background: #3679cd url(../images/header-bg-left.png) top right repeat;
 #sidebar sub { font-weight: normal; }
 #sidebar li { padding-bottom: 8px; }
 #sidebar li li { padding-bottom: 0; }
-#sidebar li li li { list-style-type: none;  }
 #sidebar hr { height: 12px; border: 0; margin-bottom: 0; box-shadow: inset 0 12px 12px -12px rgba(0, 0, 0, 0.2); }
 #sidebar h2, h3 { margin-bottom: 1px; margin-top: 3px; }
 

--- a/docs/assets/css/help.css
+++ b/docs/assets/css/help.css
@@ -5,6 +5,9 @@ Header { background: #3679cd url(../images/header-bg-left.png) top right repeat;
         background-color: #3679cd
     }
 }
+@only screen and (min-width: 960px) {
+    header h1 { width 580px }
+}
 
 #sidebar strong { font-size: 18px; font-family: 'Architects Daughter', 'Helvetica Neue', Helvetica, Arial, serif; }
 #sidebar ul { padding-left: 0; margin-bottom: 0px; font-weight: bold; font-size: 12px; color: #474747; }

--- a/docs/assets/css/help.css
+++ b/docs/assets/css/help.css
@@ -10,8 +10,9 @@ Header { background: #3679cd url(../images/header-bg-left.png) top right repeat;
 #sidebar ul { padding-left: 0; margin-bottom: 0px; font-weight: bold; font-size: 12px; color: #474747; }
 #sidebar ul ul { font-weight: normal; }
 #sidebar sub { font-weight: normal; }
-#sidebar li { list-style-type: none; padding-bottom: 8px; }
+#sidebar li { padding-bottom: 8px; }
 #sidebar li li { padding-bottom: 0; }
+#sidebar li li li { list-style-type: none;  }
 #sidebar hr { height: 12px; border: 0; margin-bottom: 0; box-shadow: inset 0 12px 12px -12px rgba(0, 0, 0, 0.2); }
 #sidebar h2, h3 { margin-bottom: 1px; margin-top: 3px; }
 

--- a/docs/assets/css/help.css
+++ b/docs/assets/css/help.css
@@ -5,9 +5,6 @@ Header { background: #3679cd url(../images/header-bg-left.png) top right repeat;
         background-color: #3679cd
     }
 }
-@media only screen and (min-width: 768px) and (max-width: 959px) {
-  header h1, header h2 { width: 380px; }
-}
 
 #sidebar strong { font-size: 18px; font-family: 'Architects Daughter', 'Helvetica Neue', Helvetica, Arial, serif; }
 #sidebar ul { padding-left: 0; margin-bottom: 0px; font-weight: bold; font-size: 12px; color: #474747; }

--- a/docs/assets/css/help.css
+++ b/docs/assets/css/help.css
@@ -10,7 +10,7 @@ Header { background: #3679cd url(../images/header-bg-left.png) top right repeat;
 #sidebar ul { padding-left: 0; margin-bottom: 0px; font-weight: bold; font-size: 12px; color: #474747; }
 #sidebar ul ul { font-weight: normal; }
 #sidebar sub { font-weight: normal; }
-#sidebar li { padding-bottom: 8px; }
+#sidebar li { list-style-type: none; padding-bottom: 8px; }
 #sidebar li li { padding-bottom: 0; }
 #sidebar hr { height: 12px; border: 0; margin-bottom: 0; box-shadow: inset 0 12px 12px -12px rgba(0, 0, 0, 0.2); }
 #sidebar h2, h3 { margin-bottom: 1px; margin-top: 3px; }

--- a/docs/assets/css/help.css
+++ b/docs/assets/css/help.css
@@ -13,7 +13,7 @@ Header { background: #3679cd url(../images/header-bg-left.png) top right repeat;
 #sidebar li { list-style-type: none; padding-bottom: 8px; }
 #sidebar li li { padding-bottom: 0; }
 #sidebar hr { height: 12px; border: 0; margin-bottom: 0; box-shadow: inset 0 12px 12px -12px rgba(0, 0, 0, 0.2); }
-#sidebar h2 { margin-bottom: 0; margin-top: 3px; }
+#sidebar h2, h3 { margin-bottom: 0; margin-top: 3px; }
 
 #fallBack { border: 10px solid orange; padding: 5px; }
 

--- a/docs/assets/css/help.css
+++ b/docs/assets/css/help.css
@@ -13,7 +13,7 @@ Header { background: #3679cd url(../images/header-bg-left.png) top right repeat;
 #sidebar li { list-style-type: none; padding-bottom: 8px; }
 #sidebar li li { padding-bottom: 0; }
 #sidebar hr { height: 12px; border: 0; margin-bottom: 0; box-shadow: inset 0 12px 12px -12px rgba(0, 0, 0, 0.2); }
-#sidebar h2, h3 { margin-bottom: 0; margin-top: 3px; }
+#sidebar h2, h3 { margin-bottom: 1px; margin-top: 3px; }
 
 #fallBack { border: 10px solid orange; padding: 5px; }
 

--- a/docs/assets/css/help.css
+++ b/docs/assets/css/help.css
@@ -11,7 +11,7 @@ Header { background: #3679cd url(../images/header-bg-left.png) top right repeat;
 #sidebar ul ul { padding-left: 15px; font-weight: normal; }
 #sidebar sub { font-weight: normal; }
 #sidebar li { list-style-type: none; padding-bottom: 8px; }
-#sidebar li li { list-style-type: disc; padding-bottom: 0;}
+#sidebar li li { padding-bottom: 0;}
 #sidebar hr { height: 12px; border: 0; box-shadow: inset 0 12px 12px -12px rgba(0, 0, 0, 0.2); }
 
 #fallBack { border: 10px solid orange; padding: 5px; }

--- a/docs/assets/css/help.css
+++ b/docs/assets/css/help.css
@@ -13,6 +13,7 @@ Header { background: #3679cd url(../images/header-bg-left.png) top right repeat;
 #sidebar li { list-style-type: none; padding-bottom: 8px; }
 #sidebar li li { padding-bottom: 0; }
 #sidebar hr { height: 12px; border: 0; box-shadow: inset 0 12px 12px -12px rgba(0, 0, 0, 0.2); }
+#sidebar h2 { margin-bottom: 0; margin-top: 3px; }
 
 #fallBack { border: 10px solid orange; padding: 5px; }
 


### PR DESCRIPTION
## Description / purpose  of the changes

Standard sidebar for all repositories. 

* wordpress page opens on another tab (like the link to the user group)
* less space between headers and content to reduce the need for scrolling through the sidebar
* Just one bar between the standard part and the variable part
* all repositories have a contribute section pointing to its own .md files
* Dropped the bullets by css, kept the `<ul><li>` structure as that is the semantic intention. For maintenance of the common part, it might be better when all repositories (read MAE-gf) have the same structure.
* moved `Development information ` items as standard part to the pages `share`, `changes`, `stable` and `Fix-Old-Links`
* whiting -> Gertrude Whithing sampler
* [x] tesselace -> tesselace index
* about page from MAE-gf moved here, added Veronika with a link (on a new tab) to about on tesselace site
* [x] an [if-else](https://github.com/jo-pol/GroundForge-help/compare/51c164f5c41f826a89c06c1bca535e05cc86745d...59363851f5b88a3f726faa3d621e09048d58bdd6) to reduce `about us` from a hyperlink to plain text when applicable. Note that exactly one line in the common sidebar part is a plain link. 
* [x] https://github.com/d-bl/GroundForge/pull/211 sidebar only for landing page (en-intro) 
  * [x] less confusing colors for Paris variants on nets page
* [x] https://github.com/d-bl/gw-lace-to-gf/pull/10
* [x] https://github.com/d-bl/tesselace-to-gf/pull/11
* [x] https://github.com/d-bl/MAE-gf/pull/41 plain link for literature when on that page.
* [x] at least 109 broken links detected by https://www.deadlinkchecker.com/website-dead-link-checker.asp


## Notify
@d-bl/gf 

Testing: jump around between the set of forks https://jo-pol.github.io/GroundForge-help/ 
